### PR TITLE
Add toggle functionality for zsh autosuggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# macOS system files
+.DS_Store
+.config/.DS_Store
+
+# tmux logs
+tmux-client-*.log

--- a/.zshrc
+++ b/.zshrc
@@ -89,7 +89,19 @@ bindkey -s "^f" 'vf^M'
 # Ctrl-e to clear the screen
 #    Ctrl-l is used for pane switching
 bindkey '^y' clear-screen
-bindkey '^B' autosuggest-disable
+
+# Toggle autosuggestions with Ctrl+B
+autosuggest-toggle() {
+  if [[ -n $ZSH_AUTOSUGGEST_DISABLED ]]; then
+    _zsh_autosuggest_enable
+    unset ZSH_AUTOSUGGEST_DISABLED
+  else
+    _zsh_autosuggest_disable
+    ZSH_AUTOSUGGEST_DISABLED=1
+  fi
+}
+zle -N autosuggest-toggle
+bindkey '^B' autosuggest-toggle
 
 export EDITOR=nvim
 


### PR DESCRIPTION
Modified Ctrl+B binding to toggle autosuggestions on/off instead of just disabling them. Created autosuggest-toggle function that tracks state and calls the appropriate enable/disable functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)